### PR TITLE
feat(composer): add check for bin-dir

### DIFF
--- a/drushlauncher/drushlauncher.go
+++ b/drushlauncher/drushlauncher.go
@@ -49,13 +49,30 @@ func FindDrupalRoot(path string) (string, error) {
 }
 
 func GetComposerBinDir(path string) string {
-	composerJsonPath := filepath.Join(path, "composer.json")
+	var dirPath = "";
+	var composerJsonPath = filepath.Join(path, dirPath, "composer.json")
+	var composerFound = false
 
 	// Check if composer.json exist
 	if _, err := os.Stat(composerJsonPath); os.IsNotExist(err) {
-		// No way to find the bin-dir flag, return the default vendor/bin
-		return filepath.Join("vendor", "bin")
+		// Check one directory up in case Drupal webroot is in a subdirectory.
+		composerFound = false;
+	} else {
+		composerFound = true;
 	}
+
+	// Check the parent directory.
+	if !composerFound {
+		dirPath = ".."
+		composerJsonPath = filepath.Join(path, dirPath, "composer.json")
+		if _, err := os.Stat(composerJsonPath); os.IsNotExist(err) {
+			// No way to find the bin-dir flag, return the default vendor/bin
+			return filepath.Join("vendor", "bin")
+		} else {
+			composerFound = true;
+		}
+	}
+
 	composerJsonFile, err := os.Open(composerJsonPath)
 
 	// Check if we can open composer.json
@@ -83,7 +100,7 @@ func GetComposerBinDir(path string) string {
 	}
 
 	// If the bin-dir flag exists, use the value of the flag
-	binDir := filepath.Join(composerJsonValues.Config.BinDir)
+	binDir := filepath.Join(dirPath, composerJsonValues.Config.BinDir)
 
 	return binDir
 }

--- a/drushlauncher/drushlauncher.go
+++ b/drushlauncher/drushlauncher.go
@@ -96,7 +96,7 @@ func GetComposerBinDir(path string) string {
 	// Check if the bin-dir flag exists
 	if composerJsonValues.Config.BinDir == "" {
 		// If the bin-dir flag does not exist, use the default vendor/bin
-		return filepath.Join("vendor", "bin")
+		return filepath.Join(dirPath, "vendor", "bin")
 	}
 
 	// If the bin-dir flag exists, use the value of the flag

--- a/drushlauncher/drushlauncher.go
+++ b/drushlauncher/drushlauncher.go
@@ -53,13 +53,16 @@ func GetComposerBinDir(path string) string {
 
 	// Check if composer.json exist
 	if _, err := os.Stat(composerJsonPath); os.IsNotExist(err) {
-		return ""
+		// No way to find the bin-dir flag, return the default vendor/bin
+		return filepath.Join("vendor", "bin")
 	}
 	composerJsonFile, err := os.Open(composerJsonPath)
 
 	// Check if we can open composer.json
 	if err != nil {
 		fmt.Println("Error opening composer.json:", err)
+		// Here we return blank because we know there's a file but we can't read
+		// it, so we can't check for the the bin-dir flag.
 		return ""
 	}
 

--- a/drushlauncher/drushlauncher.go
+++ b/drushlauncher/drushlauncher.go
@@ -51,7 +51,7 @@ func FindDrupalRoot(path string) (string, error) {
 func GetComposerBinDir(path string) string {
 	composerJsonPath := filepath.Join(path, "composer.json")
 
-	// Check if composer.json and composer.json exist
+	// Check if composer.json exist
 	if _, err := os.Stat(composerJsonPath); os.IsNotExist(err) {
 		return ""
 	}

--- a/drushlauncher/drushlauncher.go
+++ b/drushlauncher/drushlauncher.go
@@ -4,16 +4,29 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"encoding/json"
+	"io/ioutil"
 )
 
-func FindDrupalRoot(path string) (string, error) {
-	// Check if the vendor/bin/drush directory exists in the current directory
-	drushDir := filepath.Join(path, "vendor", "bin", "drush")
-	if _, err := os.Stat(drushDir); err == nil {
-		// Drupal root found, return the current directory
-		return path, nil
-	}
+type ComposerJson struct {
+	Config struct {
+		BinDir string `json:"bin-dir"`
+	} `json:"config"`
+}
 
+func FindDrupalRoot(path string) (string, error) {
+  var drushDir string
+
+	// Check if the vendor/bin/drush directory exists in the current directory
+	binDir := GetComposerBinDir(path)
+
+	if (binDir != "") {
+		drushDir := filepath.Join(path, binDir, "drush")
+		if _, err := os.Stat(drushDir); err == nil {
+			// Drupal root found, return the current directory
+			return path, nil
+		}
+	}
 	// Move one level up the directory tree
 	parentDir := filepath.Dir(path)
 	if parentDir == path {
@@ -21,13 +34,53 @@ func FindDrupalRoot(path string) (string, error) {
 		return "", fmt.Errorf("Drupal root not found")
 	}
 
-	// Check if the vendor/bin/drush directory exists in the parent directory
-	drushDir = filepath.Join(parentDir, "vendor", "bin", "drush")
-	if _, err := os.Stat(drushDir); err == nil {
-		// Drupal root found in the parent directory, return the parent directory
-		return parentDir, nil
+	// Check if the drush exec file exists in the parent directory
+	binDir = GetComposerBinDir(parentDir)
+	if (binDir != "") {
+		drushDir = filepath.Join(path, binDir, "drush")
+		if _, err := os.Stat(drushDir); err == nil {
+			// Drupal root found in the parent directory, return the parent directory
+			return parentDir, nil
+		}
 	}
 
 	// Recursively continue searching in the parent directory
 	return FindDrupalRoot(parentDir)
+}
+
+func GetComposerBinDir(path string) string {
+	composerJsonPath := filepath.Join(path, "composer.json")
+
+	// Check if composer.json and composer.json exist
+	if _, err := os.Stat(composerJsonPath); os.IsNotExist(err) {
+		return ""
+	}
+	composerJsonFile, err := os.Open(composerJsonPath)
+
+	// Check if we can open composer.json
+	if err != nil {
+		fmt.Println("Error opening composer.json:", err)
+		return ""
+	}
+
+	// Close the file when we are done.
+	defer composerJsonFile.Close()
+
+	// Read the file into a byte array
+	byteValue, _ := ioutil.ReadAll(composerJsonFile)
+
+	// Parse composer.json
+	var composerJsonValues ComposerJson
+	json.Unmarshal(byteValue, &composerJsonValues)
+
+	// Check if the bin-dir flag exists
+	if composerJsonValues.Config.BinDir == "" {
+		// If the bin-dir flag does not exist, use the default vendor/bin
+		return filepath.Join("vendor", "bin")
+	}
+
+	// If the bin-dir flag exists, use the value of the flag
+	binDir := filepath.Join(composerJsonValues.Config.BinDir)
+
+	return binDir
 }

--- a/main.go
+++ b/main.go
@@ -58,7 +58,6 @@ func main() {
 	// Parse the composer.json to get the bin-dir flag.
 	// If no bin-dir flag is found, or no composer.json file use the default vendor/bin
 	var drushRoot = filepath.Join("vendor", "bin")
-
 	if (drushlauncher.GetComposerBinDir(drupalRoot) != "") {
 		drushRoot = drushlauncher.GetComposerBinDir(drupalRoot)
 	}

--- a/main.go
+++ b/main.go
@@ -57,7 +57,12 @@ func main() {
 	// Construct the full path to the drush executable
 	// Parse the composer.json to get the bin-dir flag.
 	// If no bin-dir flag is found, or no composer.json file use the default vendor/bin
-	var drushRoot = drushlauncher.GetComposerBinDir(drupalRoot) ? drushlauncher.GetComposerBinDir(drupalRoot) : filepath.Join("vendor", "bin")
+	var drushRoot = filepath.Join("vendor", "bin")
+
+	if (drushlauncher.GetComposerBinDir(drupalRoot) != "") {
+		drushRoot = drushlauncher.GetComposerBinDir(drupalRoot)
+	}
+
 	drushExec := filepath.Join(drupalRoot, drushRoot, "drush")
 
 	// Check if the drush executable exists

--- a/main.go
+++ b/main.go
@@ -56,8 +56,9 @@ func main() {
 
 	// Construct the full path to the drush executable
 	// Parse the composer.json to get the bin-dir flag.
-	// If no bin-dir flag is found, use the default vendor/bin
-	drushExec := filepath.Join(drupalRoot, drushlauncher.GetComposerBinDir(drupalRoot), "drush")
+	// If no bin-dir flag is found, or no composer.json file use the default vendor/bin
+	var drushRoot = drushlauncher.GetComposerBinDir(drupalRoot) ? drushlauncher.GetComposerBinDir(drupalRoot) : filepath.Join("vendor", "bin")
+	drushExec := filepath.Join(drupalRoot, drushRoot, "drush")
 
 	// Check if the drush executable exists
 	if _, err := os.Stat(drushExec); os.IsNotExist(err) {

--- a/main.go
+++ b/main.go
@@ -48,7 +48,9 @@ func main() {
 	}
 
 	// Construct the full path to the drush executable
-	drushExec := filepath.Join(drupalRoot, "vendor", "bin", "drush")
+	// Parse the composer.json to get the bin-dir flag.
+	// If no bin-dir flag is found, use the default vendor/bin
+	drushExec := filepath.Join(drupalRoot, drushlauncher.GetComposerBinDir(drupalRoot), "drush")
 
 	// Check if the drush executable exists
 	if _, err := os.Stat(drushExec); os.IsNotExist(err) {

--- a/main.go
+++ b/main.go
@@ -61,7 +61,6 @@ func main() {
 	if (drushlauncher.GetComposerBinDir(drupalRoot) != "") {
 		drushRoot = drushlauncher.GetComposerBinDir(drupalRoot)
 	}
-
 	drushExec := filepath.Join(drupalRoot, drushRoot, "drush")
 
 	// Check if the drush executable exists


### PR DESCRIPTION
Alright I'm going to preface this with this is the first time I've ever written Go code so hopefully it's not too terrible.

But this adds a method into the launcher to check composer for the bin-dir flag in the composer file. Otherwise it'll fallback to vendor/bin